### PR TITLE
Fix bug when exporting to file in current folder

### DIFF
--- a/dpsql/package.py
+++ b/dpsql/package.py
@@ -181,5 +181,5 @@ def _restore_resources(mapping, resources):
 
 def _ensure_dir(path):
     dirpath = os.path.dirname(path)
-    if not os.path.exists(dirpath):
+    if dirpath and not os.path.exists(dirpath):
         os.makedirs(dirpath)


### PR DESCRIPTION
In that case, `os.path.dirname('foo.json')` returns an empty string,
then `os.path.exists('')` returns True, and it tries to call
`os.makedirs('')`, which raises an IOError.
